### PR TITLE
Fix login into mantis ending with access denied.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -161,7 +161,7 @@ class auth_plugin_authmantis extends DokuWiki_Auth_Plugin {
 		$t_access_level_string = strtoupper(
 			MantisEnum::getLabel(
 				config_get( 'access_levels_enum_string' ),
-				access_get_project_level( $t_project_id )
+				access_get_project_level( $t_project_id, $p_user_id )
 			)
 		);
 		$t_access_levels = array( $t_access_level_string );


### PR DESCRIPTION
Doku wiki version 2024-02-06b interacts with mantisbt-2.25.7 incorrectly using the access_get_project_level function.

Dokuwiki uses this API internally for users other than the current logged in user and not specifying the ID breaks that functionality.

Similarly this also does not work for the session when a user is being authenticated as some global value is not actually set in the mantis project and thus the function fails as no user is found.